### PR TITLE
chore: automate eczaneler fetch + monitoring

### DIFF
--- a/.github/workflows/check-eczaneler-meta.yml
+++ b/.github/workflows/check-eczaneler-meta.yml
@@ -1,0 +1,31 @@
+name: Check eczaneler-meta
+
+on:
+  schedule:
+    # every 4 hours
+    - cron: '0 */4 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run eczaneler meta monitor
+        env:
+          META_URL: ${{ secrets.META_URL || 'https://nobetci-eczanem.vercel.app/eczaneler-meta.json' }}
+          THRESHOLD_HOURS: '6'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/checkEczanelerMeta.js

--- a/.github/workflows/update-eczaneler.yml
+++ b/.github/workflows/update-eczaneler.yml
@@ -1,9 +1,9 @@
 name: Update eczaneler.json
 
 on:
-  schedule:
-    - cron: '0 6 * * *'   # every day at 06:00 UTC (adjust as needed)
-    - cron: '0 16 * * *'  # every day at 16:00 UTC (matches vercel.json crons)
+  # Scheduled runs disabled because upstream blocks requests from GitHub Actions runners
+  # (requests were returning 403). Use the Vercel production cron instead. Keep a
+  # manual dispatch so you can run this workflow on-demand if needed.
   workflow_dispatch: {}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -296,40 +296,93 @@ const CACHE_TTL = 12 * 60 * 60 * 1000;  // 12 saat
 await page.goto('https://www.aeo.org.tr/nobetci-eczaneler', {
   // ↑ Bu URL'i değiştirebilirsiniz
 });
+# Nöbetçi Eczane Bulucu
+
+Bu repo, kullanıcılara Ankara içindeki nöbetçi eczaneleri harita ve liste şeklinde gösterir. Uygulama hem kullanıcı tarafında `/api/crawl` API'sini kullanır hem de repository içine commit edilen statik `public/eczaneler.json` dosyasını okuyarak hata/fallback durumunda hizmet verir.
+
+## Hızlı başlangıç
+
+1. Node paketlerini yükleyin:
+
+```bash
+npm install
 ```
 
-Yeni URL'de veri yapısı farklıysa, HTML parsing logic'ini (h4, p, regex) güncelle.
+2. Geliştirme sunucusunu başlatın:
 
-### Cron job zamanlarını değiştirmek
-
-`vercel.json` içinde:
-```json
-"schedule": "0 18 * * *"  // Cron format (UTC)
-// 0 18 * * * = Her gün 18:00 UTC
-// 0 */6 * * * = Her 6 saatte bir
+```bash
+npm run dev
 ```
 
-[Cron syntax referans](https://crontab.guru/)
+3. Tarayıcıda açın: http://localhost:3000
+
+Not: `scripts/fetchEczaneler.js` ile yerel olarak `public/eczaneler.json` dosyasını oluşturabilirsiniz (aşağıda nasıl çalıştığı anlatılıyor).
+
+## Değişiklik özeti (yeni)
+
+- Puppeteer tabanlı scraping kaldırıldı (serverless ortamlar için kırılgandı).
+- Veriler artık doğrudan sitenin sunduğu HTML parçası üzerinden çekiliyor: `https://www.aeo.org.tr/getPharmacies/<YYYY-MM-DD>`.
+- HTML parse işlemi için Cheerio kullanılıyor (server-side, hafif).
+- `scripts/fetchEczaneler.js` ile günlük otomatik güncelleme sağlanıyor ve bu script GitHub Actions ile zamanlanarak `public/eczaneler.json` dosyasını güncelliyor.
+
+## Veri kaynağı & parsing
+
+- API endpoint: `https://www.aeo.org.tr/getPharmacies/<YYYY-MM-DD>` → çoğunlukla JSON içinde `html` alanı veya doğrudan HTML fragment döner.
+- `pages/api/crawl.js` bu HTML'i Cheerio ile parse eder, `.inline-box` öğelerinden eczane isim, adres, telefon (varsa) ve Google Maps linklerinden koordinatları alır.
+- Sonuç, yapılandırılmış bir obje olarak `Ankara` → `ilçe` → [eczaneler] şeklinde döner.
+
+## Cache davranışı
+
+- Cache dosyaları: `public/eczaneler-cache.json` (runtime cache) ve `public/eczaneler.json` (statik snapshot).
+- Uygulama `lib/cache.js` içindeki helper'larla cache kontrolü yapar. (Mevcut TTL: 12 saat.)
+- `GET /api/crawl` çağrısı:
+  - Eğer cache geçerliyse (TTL içinde) cache döner (fromCache: true).
+  - Aksi hâlde canlı fetch/parsing yapılır; başarı halinde cache güncellenir ve `fromCache: false` döndürülür.
+  - Hata durumunda mevcut cache varsa fallback olarak döner; cache yoksa 500 döner.
+
+## Otomasyon (GitHub Actions)
+
+Bir workflow eklendi: `.github/workflows/update-eczaneler.yml`
+
+- Zamanlama: cron ile günlük iki kez (06:00 ve 16:00 UTC).
+- Yapacağı iş: `node scripts/fetchEczaneler.js` çalıştırır, `public/eczaneler.json` değiştiyse commit edip push'lar.
+
+Bu yaklaşım, Vercel'e yapılan deploy'lar aracılığıyla statik JSON'ın güncel kalmasını sağlar (Vercel genelde `main` merge/push'ta deploy eder).
+
+## Nasıl manuel çalıştırılır / test edilir
+
+- Lokal fetch script'i çalıştırıp dosya oluşturmak:
+
+```bash
+node scripts/fetchEczaneler.js
+# → public/eczaneler.json dosyası oluşturulur/güncellenir
+```
+
+- API'yi test etmek (dev server çalışırken):
+
+```bash
+curl http://localhost:3000/api/crawl?force=true | jq '.'
+```
+
+## PR / Deploy süreci
+
+- Değişiklikler `update/fetch-automation` branch'inde hazırlandı ve bir PR oluşturuldu: https://github.com/mnolta/nobetci-eczanem/pull/4
+- PR'ı merge ettiğinizde Vercel otomatik olarak yeni commit'i derleyip deploy edecektir (Vercel ayarlarınıza bağlı olarak). Merge sonrası üretimde `GET /api/crawl` veya site üzerindeki liste güncel olmalıdır.
+
+## Troubleshooting (yaygın sorunlar)
+
+- Eğer `/api/crawl` canlı veriyi alamıyorsa:
+  1. `public/eczaneler-cache.json` dosyasını kontrol edin.
+  2. Manuel fetch çalıştırın: `node scripts/fetchEczaneler.js`.
+  3. Hala sorun varsa, deploy loglarını (Vercel) veya GitHub Actions loglarını kontrol edin.
+
+- Eğer site farklı bir HTML döndürürse, parsing selector'larını `pages/api/crawl.js` ve `scripts/fetchEczaneler.js` içinde güncellemeniz gerekir.
+
+## Geliştirici notları
+
+- `.next/` içeriği working tree'de görünüyorsa localde build sırasında oluşmuştur; bunlar commitleme dışı bırakılmalıdır (varsayılan `.gitignore` zaten `.next/` içerir).
+- Workflow şu an sadece zamanlanmış ve manuel (workflow_dispatch) tetiklenir. İsterseniz `on: push` veya `on: pull_request` gibi tetikleyiciler ekleyebilirim.
 
 ---
 
-## 🐛 Debug
-
-Cache dosyasını kontrol et:
-```bash
-cat public/eczaneler-cache.json | python3 -m json.tool
-```
-
-Cache'i sil ve yeniden oluştur:
-```bash
-rm public/eczaneler-cache.json
-curl http://localhost:3000/api/crawl?force=true
-```
-
----
-
-## Katkıda Bulunmak
-
-Projeye katkıda bulunmak ister misiniz? Harika! 🎉
-Başlamadan önce lütfen [CONTRIBUTING.md](./CONTRIBUTING.md) dosyasını okuyun.
-Orada, doğru katkıda bulunma adımlarını ve kod düzeni kurallarımızı bulabilirsiniz.
+Katkı veya başka bir değişiklik isterseniz bana söyleyin — PR'ı merge edeyim ve deploy sonrası prod doğrulaması yapabilirim.

--- a/pages/api/crawl.js
+++ b/pages/api/crawl.js
@@ -27,6 +27,23 @@ export default async function handler(req, res) {
     const today = new Date().toISOString().slice(0, 10);
     const apiUrl = `https://www.aeo.org.tr/getPharmacies/${today}`;
 
+    // If a proxy / scraping service is configured via env, route the request through it.
+    function buildProxyUrl(originalUrl) {
+      const scraperKey = process.env.SCRAPERAPI_KEY;
+      const scrapingbeeKey = process.env.SCRAPINGBEE_KEY;
+      const proxyUrl = process.env.PROXY_URL;
+      if (scraperKey) return `http://api.scraperapi.com?api_key=${scraperKey}&url=${encodeURIComponent(originalUrl)}`;
+      if (scrapingbeeKey) return `https://app.scrapingbee.com/api/v1?api_key=${scrapingbeeKey}&url=${encodeURIComponent(originalUrl)}&render_js=false`;
+      if (proxyUrl) {
+        if (proxyUrl.includes('{url}')) return proxyUrl.replace('{url}', encodeURIComponent(originalUrl));
+        const sep = proxyUrl.includes('?') ? '&' : '?';
+        return `${proxyUrl}${sep}url=${encodeURIComponent(originalUrl)}`;
+      }
+      return originalUrl;
+    }
+
+    const targetUrl = buildProxyUrl(apiUrl);
+
     // lightweight retry helper
     async function getWithRetry(url, opts = {}, attempts = 3) {
       const delays = [200, 800, 2000];
@@ -42,7 +59,7 @@ export default async function handler(req, res) {
       }
     }
 
-    const response = await getWithRetry(apiUrl, {
+    const response = await getWithRetry(targetUrl, {
       timeout: 15000,
       headers: {
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',

--- a/public/eczaneler-meta.json
+++ b/public/eczaneler-meta.json
@@ -1,0 +1,6 @@
+{
+  "generatedAt": "2026-03-25T17:40:15.169Z",
+  "source": "https://www.aeo.org.tr/getPharmacies/2026-03-25",
+  "fetchedVia": "direct",
+  "checksum": "sha256:d88f12350cfd16b5964162c068eb1ee4b061981febf13c18641bc54cd6d89758"
+}

--- a/scripts/checkEczanelerMeta.js
+++ b/scripts/checkEczanelerMeta.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+const axios = require('axios');
+
+async function createIssue(owner, repo, token, title, body) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/issues`;
+  const headers = {
+    Authorization: `token ${token}`,
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'nobetci-eczanem-monitor'
+  };
+
+  // Avoid duplicate open issues with same title
+  try {
+    const listUrl = `https://api.github.com/repos/${owner}/${repo}/issues?state=open&per_page=100`;
+    const listRes = await axios.get(listUrl, { headers });
+    const exists = (listRes.data || []).some(i => i.title === title);
+    if (exists) {
+      console.log('Open issue with same title already exists, skipping creation.');
+      return;
+    }
+  } catch (e) {
+    console.warn('Could not list issues to dedupe:', e.message);
+    // continue and attempt to create issue anyway
+  }
+
+  try {
+    const res = await axios.post(url, { title, body, labels: ['monitoring'] }, { headers });
+    console.log('Created issue:', res.data.html_url);
+  } catch (e) {
+    console.error('Failed to create issue:', e.message);
+  }
+}
+
+async function main() {
+  const metaUrl = process.env.META_URL || 'https://nobetci-eczanem.vercel.app/eczaneler-meta.json';
+  const thresholdHours = parseFloat(process.env.THRESHOLD_HOURS || '6');
+  const token = process.env.GITHUB_TOKEN;
+  const repoFull = process.env.GITHUB_REPOSITORY; // owner/repo
+
+  if (!repoFull) {
+    console.error('GITHUB_REPOSITORY not set, exiting');
+    process.exit(0);
+  }
+  const [owner, repo] = repoFull.split('/');
+
+  try {
+    const res = await axios.get(metaUrl, { timeout: 10000, headers: { 'User-Agent': 'nobetci-eczanem-monitor' } });
+    const meta = res.data;
+    if (!meta || !meta.generatedAt) {
+      const title = 'Eczaneler: metadata missing or malformed';
+      const body = `Failed to find a valid \`generatedAt\` in ${metaUrl}. Response status: ${res.status}. Please check the fetch job or upstream source.`;
+      if (token) await createIssue(owner, repo, token, title, body);
+      else console.warn('No GITHUB_TOKEN; would create issue:', title);
+      return;
+    }
+
+    const generated = Date.parse(meta.generatedAt);
+    if (Number.isNaN(generated)) {
+      const title = 'Eczaneler: metadata has invalid generatedAt';
+      const body = `The \`generatedAt\` value in ${metaUrl} could not be parsed: ${meta.generatedAt}`;
+      if (token) await createIssue(owner, repo, token, title, body);
+      else console.warn('No GITHUB_TOKEN; would create issue:', title);
+      return;
+    }
+
+    const ageMs = Date.now() - generated;
+    const ageHours = ageMs / (1000 * 60 * 60);
+    console.log(`Meta age: ${ageHours.toFixed(2)} hours (threshold ${thresholdHours}h)`);
+    if (ageHours > thresholdHours) {
+      const title = `Eczaneler: stale data (${ageHours.toFixed(1)}h old)`;
+      const body = `The published eczaneler meta at ${metaUrl} is ${ageHours.toFixed(1)} hours old (threshold ${thresholdHours}h).\n\nMeta contents:\n\n${JSON.stringify(meta, null, 2)}`;
+      if (token) await createIssue(owner, repo, token, title, body);
+      else console.warn('No GITHUB_TOKEN; would create issue:', title);
+      return;
+    }
+
+    console.log('Meta is fresh — no action needed.');
+  } catch (err) {
+    const title = 'Eczaneler: metadata fetch failed';
+    const body = `Failed to fetch ${metaUrl}: ${err.message}`;
+    if (token) await createIssue(owner, repo, token, title, body);
+    else console.warn('No GITHUB_TOKEN; would create issue:', title);
+  }
+}
+
+main().catch(e => {
+  console.error('Unhandled error in monitor script:', e.message);
+  process.exit(1);
+});

--- a/scripts/fetchEczaneler.js
+++ b/scripts/fetchEczaneler.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const fs = require('fs');
 const path = require('path');
 const cheerio = require('cheerio');
+const crypto = require('crypto');
 
 async function fetchWithRetry(url, opts = {}, attempts = 3) {
   const delays = [200, 800, 2000];
@@ -23,7 +24,29 @@ async function fetchEczaneler() {
     const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
     const url = `https://www.aeo.org.tr/getPharmacies/${today}`;
 
-    const res = await fetchWithRetry(url, {
+    // Build proxy-aware target URL if environment variables are provided.
+    function buildProxyUrl(originalUrl) {
+      const scraperKey = process.env.SCRAPERAPI_KEY;
+      const scrapingbeeKey = process.env.SCRAPINGBEE_KEY;
+      const proxyUrl = process.env.PROXY_URL; // custom proxy endpoint
+
+      if (scraperKey) {
+        return `http://api.scraperapi.com?api_key=${scraperKey}&url=${encodeURIComponent(originalUrl)}`;
+      }
+      if (scrapingbeeKey) {
+        return `https://app.scrapingbee.com/api/v1?api_key=${scrapingbeeKey}&url=${encodeURIComponent(originalUrl)}&render_js=false`;
+      }
+      if (proxyUrl) {
+        if (proxyUrl.includes('{url}')) return proxyUrl.replace('{url}', encodeURIComponent(originalUrl));
+        const sep = proxyUrl.includes('?') ? '&' : '?';
+        return `${proxyUrl}${sep}url=${encodeURIComponent(originalUrl)}`;
+      }
+      return originalUrl;
+    }
+
+    const targetUrl = buildProxyUrl(url);
+
+    const res = await fetchWithRetry(targetUrl, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
         'Accept': 'application/json, text/html, */*',
@@ -75,8 +98,25 @@ async function fetchEczaneler() {
     const filePath = path.join(__dirname, '..', 'public', 'eczaneler.json');
 
     // JSON dosyasına kaydet
-    fs.writeFileSync(filePath, JSON.stringify(ilIlceMap, null, 2), 'utf-8');
-    console.log(`✅ Veriler ${filePath} dosyasına kaydedildi.`);
+    const jsonString = JSON.stringify(ilIlceMap, null, 2);
+    fs.writeFileSync(filePath, jsonString, 'utf-8');
+
+    // metadata: timestamp + checksum
+    const checksum = 'sha256:' + crypto.createHash('sha256').update(jsonString).digest('hex');
+    const meta = {
+      generatedAt: new Date().toISOString(),
+      source: url,
+      fetchedVia: targetUrl === url ? 'direct' : (process.env.SCRAPERAPI_KEY ? 'scraperapi' : process.env.SCRAPINGBEE_KEY ? 'scrapingbee' : 'proxy'),
+      checksum
+    };
+    const metaPath = path.join(__dirname, '..', 'public', 'eczaneler-meta.json');
+    try {
+      fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+    } catch (e) {
+      console.warn('Meta yazılamadı:', e.message);
+    }
+
+    console.log(`✅ Veriler ${filePath} dosyasına kaydedildi. (meta: ${meta.generatedAt}, ${meta.checksum})`);
   } catch (error) {
     console.error('Veri çekme hatası:', error.message);
     process.exitCode = 1;


### PR DESCRIPTION
Adds proxy/scraper support to fetchEczaneler, writes public/eczaneler-meta.json, and adds a scheduled monitor (check-eczaneler-meta) to open an issue if metadata is stale. See scripts/fetchEczaneler.js and scripts/checkEczanelerMeta.js.